### PR TITLE
Implement preventScroll for focusable elements

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/YaClient.gwt.xml
+++ b/appinventor/appengine/src/com/google/appinventor/YaClient.gwt.xml
@@ -103,6 +103,16 @@
     <when-type-assignable class="com.google.gwt.user.client.rpc.RemoteService" />
   </generate-with>
 
+  <replace-with class="com.google.appinventor.client.utils.FocusImplStandard">
+    <when-type-is class="com.google.gwt.user.client.ui.impl.FocusImpl"/>
+    <when-property-is name="user.agent" value="gecko1_8"/>
+  </replace-with>
+
+  <replace-with class="com.google.appinventor.client.utils.FocusImplSafari">
+    <when-type-is class="com.google.gwt.user.client.ui.impl.FocusImpl"/>
+    <when-property-is name="user.agent" value="safari"/>
+  </replace-with>
+
   <!-- English language, independent of country -->
   <extend-property name="locale" values="en"/>
   <!-- Simplified Chinese -->

--- a/appinventor/appengine/src/com/google/appinventor/client/utils/FocusImplSafari.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/utils/FocusImplSafari.java
@@ -1,0 +1,21 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.utils;
+
+import com.google.gwt.dom.client.Element;
+
+/**
+ * FocusImplSafari extends the GWT class of the same name in order to pass
+ * the preventScroll option when an element is focused programmatically.
+ */
+public class FocusImplSafari extends com.google.gwt.user.client.ui.impl.FocusImplSafari {
+  @Override
+  public native void focus(Element elem)/*-{
+    $wnd.setTimeout(function() {
+      elem.focus({'preventScroll': true});
+    }, 0);
+  }-*/;
+}

--- a/appinventor/appengine/src/com/google/appinventor/client/utils/FocusImplStandard.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/utils/FocusImplStandard.java
@@ -1,0 +1,19 @@
+// -*- mode: java; c-basic-offset: 2; -*-
+// Copyright 2020 MIT, All rights reserved
+// Released under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+package com.google.appinventor.client.utils;
+
+import com.google.gwt.dom.client.Element;
+
+/**
+ * FocusImplStandard extends the GWT class of the same name in order to pass
+ * the preventScroll option when an element is focused programmatically.
+ */
+public class FocusImplStandard extends com.google.gwt.user.client.ui.impl.FocusImplStandard {
+  @Override
+  public native void focus(Element elem)/*-{
+    elem.focus({'preventScroll': true});
+  }-*/;
+}


### PR DESCRIPTION
The source structure tree is based on GWT's Tree implementation, which
uses focusable elements to handle keyboard navigation. However, when
these items are selected by the user, they also cause the browser to
scroll, resulting in the view jumping around, sometimes significantly
depending on the size of the scroll offset. This change passes an
optional flag, `preventScroll`, to the native `focus` method to
suppress this browser behavior. It leverage's GWT's mechanism for
making compile-time substitutions of classes to replace the GWT
implementation with an App Inventor-specific implementation.

Change-Id: I4766e5a3c119ee461d8f20dc359f4d9cdec112c0